### PR TITLE
fix: canvas resize on window resize

### DIFF
--- a/canvas-grid.js
+++ b/canvas-grid.js
@@ -117,6 +117,9 @@
     
     cols = Math.ceil(width / CELL_SIZE);
     rows = Math.ceil(height / CELL_SIZE);
+    
+    // Re-cache symbols after resize to ensure proper rendering
+    cacheSymbols();
   }
 
   function detectColorScheme() {

--- a/gradient-background.js
+++ b/gradient-background.js
@@ -395,22 +395,25 @@
     if (!canvas || !gl) return;
     
     const dpr = window.devicePixelRatio || 1;
-    const rect = canvas.getBoundingClientRect();
+    
+    // Use window dimensions directly for full viewport coverage
+    const width = window.innerWidth;
+    const height = window.innerHeight;
     
     // Check if we got valid dimensions
-    if (rect.width === 0 || rect.height === 0) {
-      console.warn('Canvas has zero dimensions, retrying...');
+    if (width === 0 || height === 0) {
+      console.warn('Window has zero dimensions, retrying...');
       setTimeout(handleResize, 100);
       return;
     }
     
-    canvas.width = rect.width * dpr;
-    canvas.height = rect.height * dpr;
-    canvas.style.width = rect.width + 'px';
-    canvas.style.height = rect.height + 'px';
+    canvas.width = width * dpr;
+    canvas.height = height * dpr;
+    canvas.style.width = width + 'px';
+    canvas.style.height = height + 'px';
     
     gl.viewport(0, 0, canvas.width, canvas.height);
-    console.log('Canvas resized:', rect.width, 'x', rect.height);
+    console.log('Canvas resized:', width, 'x', height);
   }
 
   function animate() {


### PR DESCRIPTION
- gradient-canvas: Use window dimensions directly for proper viewport sizing
- pixel-canvas: Re-cache symbols after resize to ensure correct rendering
- Both canvases now properly update when browser window is resized

🤖 Generated with Claude Code