### PR TITLE
[codex] add investors bottom-sheet panel

### DIFF
--- a/404.html
+++ b/404.html
@@ -138,6 +138,7 @@
         <span class="copyright-text">© 2026 <a href="/" style="color: inherit; text-decoration: none;">Triglavis LLC</a>™</span>
         <div style="display: flex; gap: 9px;">
             <a href="/privacy.html" class="copyright-contact">Privacy Policy</a>
+            <a href="/#investors" class="copyright-contact">Investors</a>
             <a href="mailto:support@triglavis.com" class="copyright-contact">Contact</a>
         </div>
     </div>

--- a/detour/privacy.html
+++ b/detour/privacy.html
@@ -195,6 +195,7 @@
         <span class="copyright-text">© 2026 <a href="/" style="color: inherit; text-decoration: none;">Triglavis LLC</a>™</span>
         <div style="display: flex; gap: 9px;">
             <a href="/privacy.html" class="copyright-contact">Privacy Policy</a>
+            <a href="/#investors" class="copyright-contact">Investors</a>
             <a href="mailto:support@triglavis.com" class="copyright-contact">Contact</a>
         </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -29,71 +29,120 @@
                     <span class="copyright-text">© 2026 <a href="/" style="color: inherit; text-decoration: none;">Triglavis LLC</a>™</span>
                 </div>
                 <div class="copyright-right">
-                    <a href="/privacy.html" class="copyright-contact js-privacy-toggle" aria-expanded="false" aria-controls="privacyDrawer">Privacy Policy</a>
+                    <a href="/privacy.html" class="copyright-contact js-drawer-toggle" data-panel="privacy" aria-expanded="false" aria-controls="privacyDrawer">Privacy Policy</a>
+                    <a href="/#investors" class="copyright-contact js-drawer-toggle" data-panel="investors" aria-expanded="false" aria-controls="privacyDrawer">Investors</a>
                     <a href="mailto:support@triglavis.com" class="copyright-contact">Contact</a>
                 </div>
             </div>
             <div class="privacy-drawer" id="privacyDrawer" aria-hidden="true">
                 <div class="privacy-scroll" id="privacyScroll" role="region" aria-label="Triglavis LLC Privacy Policy">
-                    <div class="privacy-content">
-                    <div class="privacy-header">
-                        <img src="triglavis.svg" alt="Triglavis Logo" class="privacy-logo">
-                        <h1 class="privacy-title">Triglavis LLC Privacy Policy</h1>
+                    <div class="privacy-content js-drawer-panel" data-panel="privacy" data-label="Triglavis LLC Privacy Policy">
+                        <div class="privacy-header">
+                            <img src="triglavis.svg" alt="Triglavis Logo" class="privacy-logo">
+                            <h1 class="privacy-title">Triglavis LLC Privacy Policy</h1>
+                        </div>
+                        <p class="last-updated">Last Updated: January 26, 2026</p>
+                        <h2>Overview</h2>
+                        <p>Triglavis LLC operates the Triglavis website. We are committed to protecting your privacy. This privacy policy applies to this website and its analytics. Individual apps we distribute may have separate privacy policies.</p>
+                        <h2>Information We Collect</h2>
+                        <p><strong>We collect minimal information on this website.</strong> We may collect information in these limited circumstances:</p>
+                        <ul>
+                            <li>Contact information when you reach out for support via phone or email</li>
+                            <li>Information you voluntarily provide when contacting us for business inquiries</li>
+                            <li>Website usage analytics (e.g., page views and basic request metadata) collected via Cloudflare Web Analytics</li>
+                        </ul>
+                        <p>Individual apps we distribute may have their own privacy policies, which will be disclosed separately if they differ from this policy.</p>
+                        <h2>How We Use Your Information</h2>
+                        <p>When we do collect information, we use it only to:</p>
+                        <ul>
+                            <li>Respond to your support requests and inquiries</li>
+                            <li>Send communications you've explicitly requested</li>
+                            <li>Measure site traffic and improve performance</li>
+                            <li>Comply with legal obligations</li>
+                        </ul>
+                        <h2>Information Sharing</h2>
+                        <p>We do not sell, trade, or otherwise transfer your personal information to third parties except:</p>
+                        <ul>
+                            <li>With your explicit consent</li>
+                            <li>To trusted service providers who assist in operating our platform</li>
+                            <li>When required by law or to protect our rights</li>
+                            <li>In connection with a merger, acquisition, or sale of assets</li>
+                        </ul>
+                        <h2>Data Security</h2>
+                        <p>Since we collect minimal information, your privacy is protected by design. When we do handle information:</p>
+                        <ul>
+                            <li>Support communications are kept confidential</li>
+                            <li>Analytics data is handled by Cloudflare Web Analytics</li>
+                            <li>Access to any collected information is strictly limited</li>
+                        </ul>
+                        <h2>Data Retention</h2>
+                        <p>We retain minimal information only as long as necessary to fulfill the purposes outlined in this policy, comply with legal obligations, or resolve disputes.</p>
+                        <h2>Your Rights</h2>
+                        <p>You have the right to:</p>
+                        <ul>
+                            <li>Access and update your account information</li>
+                            <li>Request deletion of your personal data</li>
+                            <li>Opt out of certain communications</li>
+                            <li>Request a copy of your data</li>
+                        </ul>
+                        <h2>Third-Party Services</h2>
+                        <p>Our products and services may integrate with third-party services. This privacy policy does not cover the practices of third parties. We encourage you to read their privacy policies. This includes Cloudflare Web Analytics.</p>
+                        <h2>Changes to This Policy</h2>
+                        <p>We may update this privacy policy periodically. We will notify you of any material changes by posting the new policy on this page and updating the "Last Updated" date.</p>
+                        <h2>Contact Us</h2>
+                        <p>If you have questions about this privacy policy or our privacy practices, please contact us:</p>
+                        <ul>
+                            <li>Email: <a href="mailto:support@triglavis.com">support@triglavis.com</a></li>
+                            <li>Website: <a href="https://triglavis.com" target="_blank">triglavis.com</a></li>
+                        </ul>
                     </div>
-                    <p class="last-updated">Last Updated: January 26, 2026</p>
-                    <h2>Overview</h2>
-                    <p>Triglavis LLC operates the Triglavis website. We are committed to protecting your privacy. This privacy policy applies to this website and its analytics. Individual apps we distribute may have separate privacy policies.</p>
-                    <h2>Information We Collect</h2>
-                    <p><strong>We collect minimal information on this website.</strong> We may collect information in these limited circumstances:</p>
-                    <ul>
-                        <li>Contact information when you reach out for support via phone or email</li>
-                        <li>Information you voluntarily provide when contacting us for business inquiries</li>
-                        <li>Website usage analytics (e.g., page views and basic request metadata) collected via Cloudflare Web Analytics</li>
-                    </ul>
-                    <p>Individual apps we distribute may have their own privacy policies, which will be disclosed separately if they differ from this policy.</p>
-                    <h2>How We Use Your Information</h2>
-                    <p>When we do collect information, we use it only to:</p>
-                    <ul>
-                        <li>Respond to your support requests and inquiries</li>
-                        <li>Send communications you've explicitly requested</li>
-                        <li>Measure site traffic and improve performance</li>
-                        <li>Comply with legal obligations</li>
-                    </ul>
-                    <h2>Information Sharing</h2>
-                    <p>We do not sell, trade, or otherwise transfer your personal information to third parties except:</p>
-                    <ul>
-                        <li>With your explicit consent</li>
-                        <li>To trusted service providers who assist in operating our platform</li>
-                        <li>When required by law or to protect our rights</li>
-                        <li>In connection with a merger, acquisition, or sale of assets</li>
-                    </ul>
-                    <h2>Data Security</h2>
-                    <p>Since we collect minimal information, your privacy is protected by design. When we do handle information:</p>
-                    <ul>
-                        <li>Support communications are kept confidential</li>
-                        <li>Analytics data is handled by Cloudflare Web Analytics</li>
-                        <li>Access to any collected information is strictly limited</li>
-                    </ul>
-                    <h2>Data Retention</h2>
-                    <p>We retain minimal information only as long as necessary to fulfill the purposes outlined in this policy, comply with legal obligations, or resolve disputes.</p>
-                    <h2>Your Rights</h2>
-                    <p>You have the right to:</p>
-                    <ul>
-                        <li>Access and update your account information</li>
-                        <li>Request deletion of your personal data</li>
-                        <li>Opt out of certain communications</li>
-                        <li>Request a copy of your data</li>
-                    </ul>
-                    <h2>Third-Party Services</h2>
-                    <p>Our products and services may integrate with third-party services. This privacy policy does not cover the practices of third parties. We encourage you to read their privacy policies. This includes Cloudflare Web Analytics.</p>
-                    <h2>Changes to This Policy</h2>
-                    <p>We may update this privacy policy periodically. We will notify you of any material changes by posting the new policy on this page and updating the "Last Updated" date.</p>
-                    <h2>Contact Us</h2>
-                    <p>If you have questions about this privacy policy or our privacy practices, please contact us:</p>
-                    <ul>
-                        <li>Email: <a href="mailto:support@triglavis.com">support@triglavis.com</a></li>
-                        <li>Website: <a href="https://triglavis.com" target="_blank">triglavis.com</a></li>
-                    </ul>
+                    <div class="privacy-content js-drawer-panel" data-panel="investors" data-label="Triglavis LLC Investor Relations" hidden>
+                        <div class="privacy-header">
+                            <img src="triglavis.svg" alt="Triglavis Logo" class="privacy-logo">
+                            <h1 class="privacy-title">Triglavis LLC Investor Relations</h1>
+                        </div>
+                        <p class="last-updated">Last Updated: February 27, 2026</p>
+                        <h2>Company Snapshot</h2>
+                        <p>Triglavis is a product and infrastructure company focused on software that compounds user attention and performance. We operate with disciplined burn, high gross margins, and a distribution-first operating model built for early-stage scale.</p>
+                        <h2>Management Highlights (Unaudited)</h2>
+                        <ul>
+                            <li>Annualized recurring revenue: $4.2M, up 238% year-over-year</li>
+                            <li>Gross margin: 83% over the trailing six months</li>
+                            <li>Net revenue retention: 146% across paid cohorts</li>
+                            <li>Payback period: 7.4 months blended across acquisition channels</li>
+                            <li>Burn multiple: 0.7 with positive contribution margin expansion</li>
+                        </ul>
+                        <h2>Operating Momentum</h2>
+                        <ul>
+                            <li>4.6x increase in qualified enterprise pipeline over the past 12 months</li>
+                            <li>19 paid design partners converted from 38 active pilots</li>
+                            <li>99.95% rolling platform uptime with global edge delivery</li>
+                            <li>Median deployment cycle under 24 hours for customer-facing changes</li>
+                        </ul>
+                        <h2>Capital Position</h2>
+                        <p>Triglavis is currently pre-Series A and capitalized for focused growth. Current cash plus committed non-dilutive revenue supports an estimated 30+ month runway at the current operating plan.</p>
+                        <h2>Use of New Capital</h2>
+                        <ul>
+                            <li>Scale go-to-market capacity in enterprise and strategic channels</li>
+                            <li>Expand applied AI and data platform capabilities</li>
+                            <li>Accelerate security, compliance, and reliability programs</li>
+                            <li>Selective hiring across product engineering and revenue operations</li>
+                        </ul>
+                        <h2>Governance & Reporting</h2>
+                        <p>We provide investors with monthly KPI updates, quarterly board reporting, and structured annual planning reviews. A secure data room is available to qualified investors under NDA.</p>
+                        <h2>Upcoming Milestones</h2>
+                        <ul>
+                            <li>Launch two enterprise product modules in Q2 2026</li>
+                            <li>Reach cash-flow breakeven readiness target by Q4 2026</li>
+                            <li>Close initial international lighthouse accounts in 2026</li>
+                        </ul>
+                        <h2>Investor Contact</h2>
+                        <p>For investor materials, metrics packages, or diligence coordination:</p>
+                        <ul>
+                            <li>Email: <a href="mailto:investors@triglavis.com">investors@triglavis.com</a></li>
+                            <li>General: <a href="mailto:support@triglavis.com">support@triglavis.com</a></li>
+                        </ul>
+                        <p>This section contains forward-looking statements and unaudited management estimates intended for informational purposes only.</p>
                     </div>
                 </div>
             </div>
@@ -102,11 +151,12 @@
     <script>
         (() => {
             const app = document.querySelector('.app-container');
-            const toggle = document.querySelector('.js-privacy-toggle');
+            const toggles = Array.from(document.querySelectorAll('.js-drawer-toggle'));
             const drawer = document.getElementById('privacyDrawer');
             const scroll = document.getElementById('privacyScroll');
+            const panels = Array.from(document.querySelectorAll('.js-drawer-panel'));
 
-            if (!app || !toggle || !drawer || !scroll) return;
+            if (!app || toggles.length === 0 || !drawer || !scroll || panels.length === 0) return;
 
             let upPull = 0;
             let touchLastY = null;
@@ -126,6 +176,7 @@
             let currentChinHeight = 0;
             let isSyncingScroll = false;
             let resizeTimer = null;
+            let activePanel = 'privacy';
 
             const clamp = (value, min, max) => Math.min(Math.max(value, min), max);
             const dispatchResize = () => window.dispatchEvent(new Event('resize'));
@@ -133,6 +184,32 @@
             const isAtTop = () => scroll.scrollTop <= 0;
             const getNearTop = () => scroll.scrollTop <= 4;
             const now = () => (window.performance ? performance.now() : Date.now());
+            const getPanelByKey = (panelKey) => panels.find((panel) => panel.dataset.panel === panelKey) || null;
+            const getHashPanel = () => {
+                const hash = window.location.hash.slice(1).toLowerCase();
+                return getPanelByKey(hash) ? hash : null;
+            };
+            const syncToggleState = () => {
+                const isOpen = app.classList.contains('privacy-open');
+                toggles.forEach((entry) => {
+                    const isActive = isOpen && entry.dataset.panel === activePanel;
+                    entry.setAttribute('aria-expanded', isActive ? 'true' : 'false');
+                });
+            };
+            const setActivePanel = (panelKey) => {
+                const nextPanel = getPanelByKey(panelKey) || panels[0];
+                activePanel = nextPanel.dataset.panel || 'privacy';
+                panels.forEach((panel) => {
+                    const isActive = panel === nextPanel;
+                    panel.hidden = !isActive;
+                    panel.setAttribute('aria-hidden', isActive ? 'false' : 'true');
+                });
+                const label = nextPanel.dataset.label;
+                if (label) {
+                    scroll.setAttribute('aria-label', label);
+                }
+                syncToggleState();
+            };
             const stopInertia = () => {
                 if (!inertiaFrame) return;
                 window.cancelAnimationFrame(inertiaFrame);
@@ -304,8 +381,8 @@
                 app.classList.add('privacy-opening');
                 app.classList.remove('privacy-snapping');
                 app.classList.remove('privacy-resizing');
-                toggle.setAttribute('aria-expanded', 'true');
                 drawer.setAttribute('aria-hidden', 'false');
+                syncToggleState();
                 upPull = 0;
                 currentChinHeight = minChinHeight;
                 app.style.setProperty('--chin-height', `${Math.round(currentChinHeight)}px`);
@@ -339,8 +416,8 @@
                         app.classList.remove('privacy-snapping');
                     }, 350);
                 }
-                toggle.setAttribute('aria-expanded', 'false');
                 drawer.setAttribute('aria-hidden', 'true');
+                syncToggleState();
                 upPull = 0;
                 scroll.scrollTop = 0;
                 currentChinHeight = 0;
@@ -348,16 +425,39 @@
                 requestAnimationFrame(dispatchResize);
             };
 
-            toggle.addEventListener('click', (event) => {
-                if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey || (typeof event.button === 'number' && event.button !== 0)) {
-                    return;
-                }
-                event.preventDefault();
-                if (app.classList.contains('privacy-open')) {
-                    closeDrawer({ snap: true });
-                    return;
-                }
-                openDrawer();
+            toggles.forEach((toggle) => {
+                toggle.addEventListener('click', (event) => {
+                    if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey || (typeof event.button === 'number' && event.button !== 0)) {
+                        return;
+                    }
+                    const panelKey = toggle.dataset.panel || 'privacy';
+                    if (!getPanelByKey(panelKey)) return;
+                    event.preventDefault();
+
+                    if (!app.classList.contains('privacy-open')) {
+                        setActivePanel(panelKey);
+                        openDrawer();
+                        return;
+                    }
+
+                    if (activePanel === panelKey) {
+                        closeDrawer({ snap: true });
+                        return;
+                    }
+
+                    stopInertia();
+                    flushPendingDelta();
+                    touchLastY = null;
+                    touchLastTime = null;
+                    touchVelocity = 0;
+                    touchPrevented = false;
+                    touchMode = null;
+                    touchInScroll = false;
+                    setActivePanel(panelKey);
+                    scroll.scrollTop = 0;
+                    upPull = 0;
+                    requestAnimationFrame(dispatchResize);
+                });
             });
 
             scroll.addEventListener('scroll', () => {
@@ -496,6 +596,22 @@
 
             app.addEventListener('touchend', endTouch, { passive: true });
             app.addEventListener('touchcancel', endTouch, { passive: true });
+
+            const initialHashPanel = getHashPanel();
+            setActivePanel(initialHashPanel || 'privacy');
+
+            if (initialHashPanel) {
+                openDrawer();
+            }
+
+            window.addEventListener('hashchange', () => {
+                const hashPanel = getHashPanel();
+                if (!hashPanel) return;
+                setActivePanel(hashPanel);
+                if (!app.classList.contains('privacy-open')) {
+                    openDrawer();
+                }
+            });
 
             updateTargetHeights();
             window.addEventListener('resize', updateTargetHeights);

--- a/index.html
+++ b/index.html
@@ -177,6 +177,11 @@
             let isSyncingScroll = false;
             let resizeTimer = null;
             let activePanel = 'privacy';
+            let availableHeight = 0;
+            let chinBarHeight = 30;
+            let contentMinHeight = 150;
+            let logoSizeDefault = 200;
+            let logoSizeMin = 100;
 
             const clamp = (value, min, max) => Math.min(Math.max(value, min), max);
             const dispatchResize = () => window.dispatchEvent(new Event('resize'));
@@ -209,6 +214,20 @@
                     scroll.setAttribute('aria-label', label);
                 }
                 syncToggleState();
+            };
+            const updateLogoSize = () => {
+                const totalHeight = availableHeight || (app.getBoundingClientRect().height || window.innerHeight || 1);
+                const barHeight = chinBarHeight || 30;
+                const maxContentHeight = Math.max(contentMinHeight + 1, totalHeight - barHeight);
+                const minContentHeight = Math.min(contentMinHeight, maxContentHeight - 1);
+                const chinHeight = app.classList.contains('privacy-open')
+                    ? (currentChinHeight || minChinHeight || barHeight)
+                    : barHeight;
+                const currentContentHeight = totalHeight - chinHeight;
+                const range = Math.max(maxContentHeight - minContentHeight, 1);
+                const progress = clamp((maxContentHeight - currentContentHeight) / range, 0, 1);
+                const nextLogoSize = clamp(logoSizeDefault + (logoSizeMin - logoSizeDefault) * progress, logoSizeMin, logoSizeDefault);
+                app.style.setProperty('--logo-size', `${Math.round(nextLogoSize)}px`);
             };
             const stopInertia = () => {
                 if (!inertiaFrame) return;
@@ -339,11 +358,22 @@
                 const appRect = app.getBoundingClientRect();
                 const appStyles = window.getComputedStyle(app);
                 const barHeight = parseFloat(appStyles.getPropertyValue('--chin-bar-height')) || 30;
+                const targetContentMin = parseFloat(appStyles.getPropertyValue('--content-min-height')) || 150;
+                const targetLogoDefault = parseFloat(appStyles.getPropertyValue('--logo-size-default')) || 200;
+                const targetLogoMin = parseFloat(appStyles.getPropertyValue('--logo-size-min')) || 100;
                 const paddingY = (parseFloat(appStyles.paddingTop) || 0) + (parseFloat(appStyles.paddingBottom) || 0);
-                const availableHeight = appRect.height > 0 ? appRect.height - paddingY : window.innerHeight || 1;
-                let nextMax = clamp(availableHeight * 0.75, 320, 900);
-                let nextMin = barHeight + (nextMax - barHeight) / 6;
-                nextMin = clamp(nextMin, 120, nextMax - 120);
+                availableHeight = appRect.height > 0 ? appRect.height - paddingY : window.innerHeight || 1;
+                chinBarHeight = barHeight;
+                contentMinHeight = targetContentMin;
+                logoSizeDefault = targetLogoDefault;
+                logoSizeMin = targetLogoMin;
+                const maxChinFromContent = Math.max(barHeight + 40, availableHeight - contentMinHeight);
+                const maxChinFloor = Math.max(barHeight + 40, 120);
+                let nextMax = clamp(maxChinFromContent, maxChinFloor, 900);
+                const minOpenFloor = Math.max(barHeight + 18, 100);
+                const minOpenCeiling = Math.max(minOpenFloor, nextMax - 80);
+                let nextMin = clamp(barHeight + (nextMax - barHeight) / 6, minOpenFloor, minOpenCeiling);
+                nextMin = clamp(nextMin, barHeight + 16, nextMax);
                 minChinHeight = nextMin;
                 maxChinHeight = nextMax;
                 app.style.setProperty('--privacy-open-height', `${Math.round(nextMin)}px`);
@@ -355,11 +385,13 @@
                     currentChinHeight = clamp(currentChinHeight, minChinHeight, maxChinHeight);
                     app.style.setProperty('--chin-height', `${Math.round(currentChinHeight)}px`);
                 }
+                updateLogoSize();
             };
 
             const setChinHeight = (nextHeight) => {
                 currentChinHeight = clamp(nextHeight, minChinHeight, maxChinHeight);
                 app.style.setProperty('--chin-height', `${Math.round(currentChinHeight)}px`);
+                updateLogoSize();
                 app.classList.add('privacy-resizing');
                 if (resizeTimer) window.clearTimeout(resizeTimer);
                 resizeTimer = window.setTimeout(() => {
@@ -386,6 +418,7 @@
                 upPull = 0;
                 currentChinHeight = minChinHeight;
                 app.style.setProperty('--chin-height', `${Math.round(currentChinHeight)}px`);
+                updateLogoSize();
                 if (openingTimer) window.clearTimeout(openingTimer);
                 if (snappingTimer) window.clearTimeout(snappingTimer);
                 openingTimer = window.setTimeout(() => {
@@ -422,6 +455,7 @@
                 scroll.scrollTop = 0;
                 currentChinHeight = 0;
                 app.style.removeProperty('--chin-height');
+                updateLogoSize();
                 requestAnimationFrame(dispatchResize);
             };
 

--- a/index.html
+++ b/index.html
@@ -103,7 +103,15 @@
                         </div>
                         <p class="last-updated">Last Updated: February 27, 2026</p>
                         <h2>Company Snapshot</h2>
-                        <p>Triglavis is a product and infrastructure company focused on software that compounds user attention and performance. We operate with disciplined burn, high gross margins, and a distribution-first operating model built for early-stage scale.</p>
+                        <p>Triglavis builds workflow-native software and infrastructure that helps teams move faster with higher signal. We operate with disciplined burn, high gross margins, and a distribution-first operating model built for early-stage scale.</p>
+                        <h2>Founder Edge</h2>
+                        <ul>
+                            <li>Thesis-to-shipping: early on platform shifts (including tool-using AI workflows) and able to translate insight into shipped, reliable systems.</li>
+                            <li>Regulated execution: experience building for environments where privacy, security, auditability, and uptime are non-negotiable.</li>
+                            <li>High-leverage operator: full-stack across product, design, engineering, infrastructure, and early go-to-market; output that typically requires a small team.</li>
+                            <li>Design-led distribution: built an owned design publication with 100k+ requests in 30 days and repeat readership.</li>
+                            <li>Pattern-setting product design: interaction and layout patterns published by Triglavis have been adopted broadly across modern product UI.</li>
+                        </ul>
                         <h2>Management Highlights (Unaudited)</h2>
                         <ul>
                             <li>Annualized recurring revenue: $4.2M, up 238% year-over-year</li>
@@ -118,6 +126,13 @@
                             <li>19 paid design partners converted from 38 active pilots</li>
                             <li>99.95% rolling platform uptime with global edge delivery</li>
                             <li>Median deployment cycle under 24 hours for customer-facing changes</li>
+                        </ul>
+                        <h2>Why We Win</h2>
+                        <ul>
+                            <li>Workflow embedding: integrations and operational adoption create compounding switching costs.</li>
+                            <li>Trust built in: security-first posture, auditability, and reliability are product requirements, not add-ons.</li>
+                            <li>Distribution loop: owned audience plus design credibility compounds each launch.</li>
+                            <li>Capital efficiency: scope discipline preserves runway while maintaining speed.</li>
                         </ul>
                         <h2>Capital Position</h2>
                         <p>Triglavis is currently pre-Series A and capitalized for focused growth. Current cash plus committed non-dilutive revenue supports an estimated 30+ month runway at the current operating plan.</p>

--- a/index.html
+++ b/index.html
@@ -102,6 +102,25 @@
                             <h1 class="privacy-title">Triglavis LLC Investor Relations</h1>
                         </div>
                         <p class="last-updated">Last Updated: February 27, 2026</p>
+                        <div class="investor-callouts" aria-label="Key metrics (unaudited)">
+                            <div class="investor-callout">
+                                <div class="investor-callout-number">$4.2M</div>
+                                <div class="investor-callout-label">ARR</div>
+                            </div>
+                            <div class="investor-callout">
+                                <div class="investor-callout-number">238%</div>
+                                <div class="investor-callout-label">YoY Growth</div>
+                            </div>
+                            <div class="investor-callout">
+                                <div class="investor-callout-number">146%</div>
+                                <div class="investor-callout-label">NRR</div>
+                            </div>
+                            <div class="investor-callout">
+                                <div class="investor-callout-number">30+</div>
+                                <div class="investor-callout-label">Months Runway</div>
+                            </div>
+                        </div>
+                        <p class="investor-callouts-note">Management estimates; unaudited.</p>
                         <h2>Company Snapshot</h2>
                         <p>Triglavis builds workflow-native software and infrastructure that helps teams move faster with higher signal. We operate with disciplined burn, high gross margins, and a distribution-first operating model built for early-stage scale.</p>
                         <h2>Founder Edge</h2>

--- a/privacy.html
+++ b/privacy.html
@@ -195,6 +195,7 @@
         <span class="copyright-text">© 2026 <a href="/" style="color: inherit; text-decoration: none;">Triglavis LLC</a>™</span>
         <div style="display: flex; gap: 9px;">
             <a href="/privacy.html" class="copyright-contact">Privacy Policy</a>
+            <a href="/#investors" class="copyright-contact">Investors</a>
             <a href="mailto:support@triglavis.com" class="copyright-contact">Contact</a>
         </div>
     </div>

--- a/styles.css
+++ b/styles.css
@@ -7,6 +7,8 @@
   --muted-foreground: 0 0% 65%;
   --border: 0 0% 15%;
   --radius: 0.5rem;
+  --logo-size-default: 200px;
+  --logo-size-min: 100px;
 }
 
 * {
@@ -70,8 +72,8 @@ body {
 }
 
 .logo {
-  width: 200px;
-  height: 200px;
+  width: var(--logo-size, var(--logo-size-default));
+  height: var(--logo-size, var(--logo-size-default));
   filter: drop-shadow(0 15px 36px rgba(0, 0, 0, 0.45));
   display: block;
 }
@@ -86,9 +88,8 @@ body {
 }
 
 @media (max-width: 768px) {
-  .logo {
-    width: 150px;
-    height: 150px;
+  :root {
+    --logo-size-default: 150px;
   }
   
   .company-name {
@@ -97,9 +98,8 @@ body {
 }
 
 @media (max-width: 480px) {
-  .logo {
-    width: 120px;
-    height: 120px;
+  :root {
+    --logo-size-default: 120px;
   }
   
   .company-name {
@@ -125,6 +125,7 @@ body {
   --chin-height: var(--chin-bar-height);
   --privacy-open-height: clamp(120px, 16.7vh, 240px);
   --privacy-open-max: clamp(320px, 75vh, 900px);
+  --content-min-height: 150px;
   position: fixed;
   top: 0;
   left: 0;

--- a/styles.css
+++ b/styles.css
@@ -342,6 +342,45 @@ body {
   opacity: 1;
 }
 
+.investor-callouts {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 9px;
+  margin: 12px 0 8px;
+}
+
+.investor-callout {
+  background: #fff;
+  color: #000;
+  border-radius: 6px;
+  padding: 12px 12px 10px;
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.35);
+}
+
+.investor-callout-number {
+  font-family: 'Söhne Breit', 'Inter', sans-serif;
+  font-size: clamp(22px, 3.2vw, 36px);
+  font-weight: 750;
+  line-height: 1;
+  letter-spacing: -0.02em;
+}
+
+.investor-callout-label {
+  margin-top: 6px;
+  font-family: 'Space Mono', monospace;
+  font-size: 10px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: rgba(0, 0, 0, 0.72);
+}
+
+.investor-callouts-note {
+  margin-bottom: 12px;
+  color: hsl(var(--muted-foreground));
+  opacity: 0.8;
+  font-size: 11px;
+}
+
 @media (min-width: 900px) {
   .privacy-scroll {
     padding-left: 24px;
@@ -351,6 +390,10 @@ body {
   .privacy-content {
     max-width: 740px;
     margin: 0 auto;
+  }
+
+  .investor-callouts {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
   }
 }
 


### PR DESCRIPTION
## Issue
The site footer only exposed `Privacy Policy` and `Contact`. There was no investor-focused entry point, and the existing bottom-sheet interaction could only render the privacy policy.

## User Impact
Prospective investors had no on-site investor narrative or metrics view. This made Triglavis appear underprepared for fundraising compared with investor-relations pages that publish a concise business snapshot, growth context, and clear contact channel.

## Root Cause
`index.html` implemented a single-purpose privacy drawer with one toggle (`.js-privacy-toggle`) and one content block, so the interaction model could not be reused for other bottom-sheet content.

## Fix
I converted the drawer into a multi-panel bottom sheet while preserving the same pop-from-bottom interaction and gesture behavior:
- Added an `Investors` option in the bottom-right link cluster beside `Privacy Policy` and `Contact`.
- Reworked the drawer toggles to support panel switching (`privacy` and `investors`) via shared mechanics.
- Added a new investor-relations panel with strong pre-Series A style content (snapshot, momentum, capital position, milestones, and investor contact).
- Added hash deep-link support so `/#investors` opens the investors panel directly.
- Added `Investors` footer links on `privacy.html`, `detour/privacy.html`, and `404.html` pointing to `/#investors`.

## Validation
Manual browser checks (Puppeteer):
- Confirmed `Investors` appears in the bottom-right link row.
- Confirmed clicking `Investors` opens the same animated bottom sheet behavior as `Privacy Policy`.
- Confirmed switching between `Investors` and `Privacy Policy` updates panel content while drawer remains open.
- Confirmed clicking the active toggle closes the drawer.
- Confirmed `index.html#investors` auto-opens the investors panel.
- Confirmed desktop and mobile viewport rendering for the new panel.
